### PR TITLE
Single node bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+## [0.2.2] - 2020-04-06
+### Fixed
+- Endframe was not being cacluated correctly when the start frame was non-zero. So end
+  endframe is now `offset + start frame [+ remainder if last task]` 
+  ([#40](https://github.com/OSC/frame-renderer/pull/40)).
+- +1 offset was incorrect and only needs to be applied to start frame if the pbs
+  id is > 1.
 
 ## [0.2.1] - 2020-04-03
 ### Fixed
@@ -22,7 +29,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - ensure app doesn't crash if there is no `~/maya/projects` directory [#30](https://github.com/OSC/frame-renderer/issues/30)
 
-[Unreleased]: https://github.com/OSC/frame-renderer/compare/0.2.1...HEAD
+[Unreleased]: https://github.com/OSC/frame-renderer/compare/0.2.2...HEAD
+[0.2.2]: https://github.com/OSC/frame-renderer/compare/0.2.1...0.2.2
 [0.2.1]: https://github.com/OSC/frame-renderer/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/OSC/frame-renderer/compare/0.1.1...0.2.0
 [0.1.1]: https://github.com/OSC/frame-renderer/compare/0.1.0...0.1.1

--- a/jobs/video_jobs/maya_submit.sh.erb
+++ b/jobs/video_jobs/maya_submit.sh.erb
@@ -31,6 +31,39 @@ function create_thumbnails(){
   done
 }
 
+function start_frame(){
+  if [ -z "$PBS_ARRAYID" ]; then
+    PBS_ARRAYID=1
+  fi
+  
+  if [ $PBS_ARRAYID -gt 1 ]; then
+    # if nodes >1 have to offset +1 so the start frame of this task
+    # doesn't overlap with the end frame of the previous task
+    TASK_START_FRAME=$(( OFFSET - TASK_SIZE + START_FRAME + 1 ))
+  elif [ "$NODES" != "1" ]; then
+    TASK_START_FRAME=$(( OFFSET - TASK_SIZE + START_FRAME ))
+  else
+    TASK_START_FRAME=$START_FRAME
+  fi
+
+  echo $TASK_START_FRAME
+}
+
+function end_frame(){
+
+  if [ $REMAINDER -ne 0 ] && [ "$PBS_ARRAYID" -eq "$NODES" ]; then
+    # last task picks up the remainder of the frames
+    TASK_END_FRAME=$(( OFFSET + START_FRAME + REMAINDER ))
+    echo $REMAINDER
+  elif [ "$NODES" != "1" ]; then
+    TASK_END_FRAME=$(( OFFSET + START_FRAME ))
+  else
+    TASK_END_FRAME=$END_FRAME
+  fi
+
+  echo $TASK_END_FRAME
+}
+
 echo "starting at $(date)"
 
 #load the singularity and ACCAD modules and record the loaded module list
@@ -42,35 +75,21 @@ module load maya/2018-ACCAD
 # set all the different variables you'll need 
 CMD="singularity exec -B $DIR_BINDS $MAYA_IMG Render"
 RENDERER="<%= renderer %>"
-NODES=<%= nodes %>
-START_FRAME="<%= start_frame %>"
-END_FRAME="<%= end_frame %>"
 EXTRA_ARGS="<%= extra %>"
 FILE="<%= file %>"
 PRJ_DIR="<%= project_dir %>"
 SKIP_EXISTING="-skipExistingFrames <%= skip_existing %>"
-TOTAL_FRAMES=$(( END_FRAME - START_FRAME ))
-TASK_SIZE=$(( TOTAL_FRAMES / NODES ))
-REMAINDER=$(( TOTAL_FRAMES % NODES ))
 
-OFFSET=$(( PBS_ARRAYID * TASK_SIZE ))
 
-if [ $PBS_ARRAYID -gt 1 ]; then
-  # if nodes >1 have to offset +1 so the start frame of this task
-  # doesn't overlap with the end frame of the previous task
-  TASK_START_FRAME=$(( OFFSET - TASK_SIZE + START_FRAME + 1 ))
-else
-  TASK_START_FRAME=$(( OFFSET - TASK_SIZE + START_FRAME ))
-fi
+export NODES=<%= nodes %>
+export START_FRAME="<%= start_frame %>"
+export END_FRAME="<%= end_frame %>"
+export TOTAL_FRAMES=$(( END_FRAME - START_FRAME ))
+export TASK_SIZE=$(( TOTAL_FRAMES / NODES ))
+export REMAINDER=$(( TOTAL_FRAMES % NODES ))
+export OFFSET=$(( PBS_ARRAYID * TASK_SIZE ))
 
-if [ $REMAINDER -ne 0 ] && [ "$PBS_ARRAYID" -eq "$NODES" ]; then
-  # last task picks up the remainder of the frames
-  TASK_END_FRAME=$(( OFFSET + START_FRAME + REMAINDER ))
-else
-  TASK_END_FRAME=$(( OFFSET + START_FRAME ))
-fi
-
-ARGS="-r $RENDERER $SKIP_EXISTING ${EXTRA_ARGS} -proj $PRJ_DIR -s $TASK_START_FRAME -e $TASK_END_FRAME $FILE"
+ARGS="-r $RENDERER $SKIP_EXISTING ${EXTRA_ARGS} -proj $PRJ_DIR -s $(start_frame) -e $(end_frame) $FILE"
 
 echo "executing: $CMD $ARGS"
 echo "on host: $(hostname)"

--- a/jobs/video_jobs/maya_submit.sh.erb
+++ b/jobs/video_jobs/maya_submit.sh.erb
@@ -54,7 +54,6 @@ function end_frame(){
   if [ $REMAINDER -ne 0 ] && [ "$PBS_ARRAYID" -eq "$NODES" ]; then
     # last task picks up the remainder of the frames
     TASK_END_FRAME=$(( OFFSET + START_FRAME + REMAINDER ))
-    echo $REMAINDER
   elif [ "$NODES" != "1" ]; then
     TASK_END_FRAME=$(( OFFSET + START_FRAME ))
   else


### PR DESCRIPTION
Refactor start and end frame functions so that they're testable. This also fixes a bug where it calculates the offset for jobs with one node. Jobs with one only node don't need start and end frame re-calculation.
