### PR TITLE
url and shell escape 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,5 +50,6 @@ gem 'js-routes', '~> 1.2.4'
 gem 'local_time', '~> 1.0.3'
 gem 'ood_appkit', '~> 1.0'
 gem 'ood_core', '~> 0.9.3'
+gem 'shellwords', '~> 0.1'
 
 gem 'nokogiri', '>= 1.10.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shellwords (0.1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -201,6 +202,7 @@ DEPENDENCIES
   rails (= 4.2.11.1)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shellwords (~> 0.1)
   sqlite3 (~> 1.3.6)
   turbolinks
   uglifier (>= 1.3.0)

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -18,7 +18,7 @@ module ProjectsHelper
 
   def image_to_thumbnail(project_dir, image)
     basename = File.basename(image, File.extname(image))
-    project_dir + '/thumbnails/' + basename + '.png'
+    "#{project_dir}/thumbnails/#{url_encode(basename)}.png"
   end
 
   private

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -79,10 +79,11 @@
         <% images(@project.directory).each do |image| %>
           <tr>
             <td>
-            <%= link_to(
-                File.basename(image),
-                "/pun/sys/files/api/v1/fs" + image + '?download=1'
-                )%>
+            <%-
+              basename = File.basename(image)
+              dir = File.dirname(image)
+            -%>
+            <%= link_to(basename, "/pun/sys/files/fs#{dir}/#{url_encode(basename)}?download=1") %>
             <td>
               <img 
                 class="d-block w-100 thumbnail-zoom" 

--- a/jobs/video_jobs/maya_submit.sh.erb
+++ b/jobs/video_jobs/maya_submit.sh.erb
@@ -38,8 +38,8 @@ def create_thumbnails
 
   images.each do |img|
     fname = File.basename(img, ".*")
-    puts "creating thumbnail for #{fname}"
-    system("convert #{img} #{convert_args} #{thumb_dir}/#{fname}.png")
+    puts "creating thumbnail for '#{fname}'"
+    system("convert '#{img}' #{convert_args} '#{thumb_dir}/#{fname}.png'")
   end
 
 end
@@ -72,11 +72,9 @@ BIND_DIRS="$BIND_DIRS,$JOB_TMPDIR/Autodesk:/var/opt/Autodesk"
 # init the tmpdir
 TMPDIR=$JOB_TMPDIR maya_init.sh
 
-# set all the different variables you'll need 
-CMD="singularity exec -B $BIND_DIRS $MAYA_IMG Render"
+# set all the different variables you'll need
 RENDERER="<%= renderer %>"
 EXTRA_ARGS="<%= extra %>"
-FILE="<%= file %>"
 PRJ_DIR="<%= project_dir %>"
 SKIP_EXISTING="-skipExistingFrames <%= skip_existing %>"
 
@@ -88,15 +86,16 @@ END_FRAMES=(shift <%= task_end_frames.join(' ')%>)
 export TASK_START_FRAME=${START_FRAMES[$PBS_ARRAYID]}
 export TASK_END_FRAME=${END_FRAMES[$PBS_ARRAYID]}
 
-ARGS="-r $RENDERER $SKIP_EXISTING ${EXTRA_ARGS} -proj $PRJ_DIR -s $TASK_START_FRAME -e $TASK_END_FRAME $FILE"
+CMD=(singularity exec -B $BIND_DIRS $MAYA_IMG Render)
+CMD+=(-r $RENDERER $SKIP_EXISTING ${EXTRA_ARGS} -proj $PRJ_DIR -s $TASK_START_FRAME -e $TASK_END_FRAME)
 
-echo "executing: $CMD $ARGS"
+echo "executing: ${CMD[@]} <%= Shellwords.escape(file) %>"
 echo "on host: $(hostname)"
 echo "with modules:"
 module list
 
 # now let's actually execute and grab the end status
-${CMD} ${ARGS}
+${CMD[@]} <%= Shellwords.escape(file) %>
 STATUS=$?
 
 echo "ended at $(date)"


### PR DESCRIPTION
Fixes #43 

This allows for strange names in the filename being rendered as well as strange names being generated as output. 

I was testing with the string `spaces !%&$ $SHELL` for both. 

![image](https://user-images.githubusercontent.com/4874123/100278615-2e351380-2f33-11eb-99f6-3dcb1890ec8f.png)
