### PR TITLE
Bug fixes

### DIFF
--- a/app/models/script.rb
+++ b/app/models/script.rb
@@ -167,21 +167,16 @@ class Script < ActiveRecord::Base
     task_size.zero? ? 1 : task_size
   end
 
-  def offset(array_id)
-    array_id == 1 ? task_size : (array_id - 1) * task_size
-  end
-
   def task_start_frame(array_id)
     if nodes == 1
       start_frame
     elsif task_size == 1
       # you have as many nodes as there are tasks
       start_frame.zero? ? array_id - 1 : array_id
-    elsif array_id > 1
-      start_frame + offset(array_id)
-    else
-      # array id == 1
+    elsif array_id == 1
       start_frame
+    else
+      task_end_frame(array_id - 1) + 1
     end
   end
 
@@ -194,11 +189,8 @@ class Script < ActiveRecord::Base
           elsif task_size == 1
             # you have as many nodes as there are tasks
             array_id
-          elsif array_id > 1
-            offset(array_id) + task_size
           else
-            # array id == 1
-            offset(1)
+            task_start_frame(array_id) + task_size
           end
 
     shift_end_frame(array_id) ? ef - 1 : ef

--- a/jobs/video_jobs/maya_submit.sh.erb
+++ b/jobs/video_jobs/maya_submit.sh.erb
@@ -83,6 +83,9 @@ SKIP_EXISTING="-skipExistingFrames <%= skip_existing %>"
 START_FRAMES=(shift <%= task_start_frames.join(' ')%>)
 END_FRAMES=(shift <%= task_end_frames.join(' ')%>)
 
+# if it's a single node, PBS_ARRAYID isn't set so set it to 1
+[ -n "$PBS_ARRAYID" ] || PBS_ARRAYID=1
+
 export TASK_START_FRAME=${START_FRAMES[$PBS_ARRAYID]}
 export TASK_END_FRAME=${END_FRAMES[$PBS_ARRAYID]}
 

--- a/test/models/script_test.rb
+++ b/test/models/script_test.rb
@@ -16,8 +16,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test "task frames evenly spit across many nodes starting from 1" do
     script = Script.new(frames: '1-30', nodes: '3')
-    assert_equal [1, 11, 21], script.task_start_frames
-    assert_equal [10, 20, 30], script.task_end_frames
+    assert_equal [1, 12, 23], script.task_start_frames
+    assert_equal [11, 22, 30], script.task_end_frames
   end
 
   test "task frames evenly spit across many nodes starting from 0" do
@@ -28,8 +28,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test "task frames un-evenly spit across many nodes starting from 1" do
     script = Script.new(frames: '1-50', nodes: '3')
-    assert_equal [1, 17, 33], script.task_start_frames
-    assert_equal [16, 32, 50], script.task_end_frames
+    assert_equal [1, 18, 35], script.task_start_frames
+    assert_equal [17, 34, 50], script.task_end_frames
   end
 
   test "task frames un-evenly spit across many nodes starting from 0" do
@@ -60,5 +60,23 @@ class ScriptTest < ActiveSupport::TestCase
     script = Script.new(frames: '1-10', nodes: '9')
     assert_equal [1, 2, 3, 4, 5, 6, 7, 8, 9], script.task_start_frames
     assert_equal [1, 2, 3, 4, 5, 6, 7, 8, 10], script.task_end_frames
+  end
+
+  test "task frames starting from >> 1 with 1 node" do
+    script = Script.new(frames: '101-200', nodes: '1')
+    assert_equal [101], script.task_start_frames
+    assert_equal [200], script.task_end_frames
+  end
+
+  test "task frames starting from >> 1 with 4 nodes" do
+    script = Script.new(frames: '101-200', nodes: '4')
+    assert_equal [101, 127, 153, 179], script.task_start_frames
+    assert_equal [126, 152, 178, 200], script.task_end_frames
+  end
+
+  test "task frames starting from >> 1 with many nodes" do
+    script = Script.new(frames: '254-10034', nodes: '15')
+    assert_equal [254, 907, 1560, 2213, 2866, 3519, 4172, 4825, 5478, 6131, 6784, 7437, 8090, 8743, 9396], script.task_start_frames
+    assert_equal [906, 1559, 2212, 2865, 3518, 4171, 4824, 5477, 6130, 6783, 7436, 8089, 8742, 9395, 10034], script.task_end_frames
   end
 end


### PR DESCRIPTION
Fix a couple bugs.

- One is running with a single node and an expression like `TASK_START_FRAME=${START_FRAMES[$PBS_ARRAYID]}` fails because PBS_ARRAYID isn't set, so set it to 1.
- Secondly, simplify start and end frame calculations by removing the offset calculation. There's a bug where frames like 101-200 would result in end frames [25, 50, 27, 200] which are clearly wrong because they're less than 101.