### PR TITLE
bugfix for end_frames including start frame

### DIFF
--- a/app/models/script.rb
+++ b/app/models/script.rb
@@ -168,7 +168,7 @@ class Script < ActiveRecord::Base
   end
 
   def task_start_frame(array_id)
-    if nodes == 1
+    if tasks == 1
       start_frame
     elsif task_size == 1
       # you have as many nodes as there are tasks
@@ -181,26 +181,20 @@ class Script < ActiveRecord::Base
   end
 
   def task_end_frame(array_id)
-    ef  = if nodes == 1
-            end_frame
-          elsif last_task?(array_id)
-            # last task just picks up all the rest
-            end_frame
-          elsif task_size == 1
-            # you have as many nodes as there are tasks
-            array_id
-          else
-            task_start_frame(array_id) + task_size
-          end
-
-    shift_end_frame(array_id) ? ef - 1 : ef
-  end
-
-  def shift_end_frame(array_id)
-    # any endframe needs to be left shifted if start_frame is 0
-    # bc offsets and array_id all start at 1. EXCEPT the very last
-    # task which can pick up any remaining frames
-    !last_task?(array_id) && (start_frame.zero? && tasks != 1)
+    if tasks == 1
+      end_frame
+    elsif last_task?(array_id)
+      # last task just picks up all the rest
+      end_frame
+    elsif task_size == 1
+      # you have as many nodes as there are tasks
+      start_frame.zero? ? array_id - 1 : array_id
+    else
+      # have to shift everything -1 because task_size
+      # is always > 1 here, but task_size includes start frame
+      ef = task_start_frame(array_id) + task_size
+      last_task?(array_id) ? ef : ef - 1
+    end
   end
 
   def last_task?(array_id)

--- a/test/models/script_test.rb
+++ b/test/models/script_test.rb
@@ -16,8 +16,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test "task frames evenly spit across many nodes starting from 1" do
     script = Script.new(frames: '1-30', nodes: '3')
-    assert_equal [1, 12, 23], script.task_start_frames
-    assert_equal [11, 22, 30], script.task_end_frames
+    assert_equal [1, 11, 21], script.task_start_frames
+    assert_equal [10, 20, 30], script.task_end_frames
   end
 
   test "task frames evenly spit across many nodes starting from 0" do
@@ -28,8 +28,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test "task frames un-evenly spit across many nodes starting from 1" do
     script = Script.new(frames: '1-50', nodes: '3')
-    assert_equal [1, 18, 35], script.task_start_frames
-    assert_equal [17, 34, 50], script.task_end_frames
+    assert_equal [1, 17, 33], script.task_start_frames
+    assert_equal [16, 32, 50], script.task_end_frames
   end
 
   test "task frames un-evenly spit across many nodes starting from 0" do
@@ -70,13 +70,25 @@ class ScriptTest < ActiveSupport::TestCase
 
   test "task frames starting from >> 1 with 4 nodes" do
     script = Script.new(frames: '101-200', nodes: '4')
-    assert_equal [101, 127, 153, 179], script.task_start_frames
-    assert_equal [126, 152, 178, 200], script.task_end_frames
+    assert_equal [101, 126, 151, 176], script.task_start_frames
+    assert_equal [125, 150, 175, 200], script.task_end_frames
   end
 
   test "task frames starting from >> 1 with many nodes" do
     script = Script.new(frames: '254-10034', nodes: '15')
-    assert_equal [254, 907, 1560, 2213, 2866, 3519, 4172, 4825, 5478, 6131, 6784, 7437, 8090, 8743, 9396], script.task_start_frames
-    assert_equal [906, 1559, 2212, 2865, 3518, 4171, 4824, 5477, 6130, 6783, 7436, 8089, 8742, 9395, 10034], script.task_end_frames
+    assert_equal [254, 906, 1558, 2210, 2862, 3514, 4166, 4818, 5470, 6122, 6774, 7426, 8078, 8730, 9382], script.task_start_frames
+    assert_equal [905, 1557, 2209, 2861, 3513, 4165, 4817, 5469, 6121, 6773, 7425, 8077, 8729, 9381, 10034], script.task_end_frames
+  end
+
+  test "task size is 2 but numbered start - end is only 1" do
+    script = Script.new(frames: '1-20', nodes: '10')
+    assert_equal [1, 3, 5, 7, 9, 11, 13, 15, 17, 19], script.task_start_frames
+    assert_equal [2, 4, 6, 8, 10, 12, 14, 16, 18, 20], script.task_end_frames
+  end
+
+  test "task size is 2 but numbered start - end is only 1 starting from 0" do
+    script = Script.new(frames: '0-20', nodes: '10')
+    assert_equal [0, 2, 4, 6, 8, 10, 12, 14, 16, 18], script.task_start_frames
+    assert_equal [1, 3, 5, 7, 9, 11, 13, 15, 17, 20], script.task_end_frames
   end
 end


### PR DESCRIPTION
There was a bug where end_frames where not exactly counted right and this was particularly bad if the task_size was 2. This fix
now includes the start_frame in the task_size when determining end_frame. I.e., a start_frame of 5 + task_size of 5 returned and end_frame of 10, but that actually should be 9 because frame 5 is included in the task.