### PR TITLE
genereate secret key during build

### DIFF
--- a/packaging/frame_renderer.spec
+++ b/packaging/frame_renderer.spec
@@ -46,6 +46,7 @@ scl enable ondemand - << \EOS
 export GEM_HOME=$(pwd)/gems-build
 export GEM_PATH=$(pwd)/gems-build:$GEM_PATH
 export PASSENGER_APP_ENV=production
+export SECRET_KEY_BASE=$(bin/rake secret)
 bin/setup
 EOS
 


### PR DESCRIPTION
genereate secret key during build otherwise we get an error during build similar to this:

```text
== Compiling assets ==
bin/rake assets:clobber
/home/jeff/.rvm/gems/ruby-2.7.1/gems/actionpack-5.2.4.4/lib/action_dispatch/middleware/stack.rb:37: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/jeff/.rvm/gems/ruby-2.7.1/gems/actionpack-5.2.4.4/lib/action_dispatch/middleware/static.rb:111: warning: The called method `initialize' is defined here
/home/jeff/.rvm/gems/ruby-2.7.1/gems/json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated
rake aborted!
ArgumentError: Missing `secret_key_base` for 'production' environment, set this string with `rails credentials:edit`
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/application.rb:585:in `validate_secret_key_base'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/application.rb:432:in `secret_key_base'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/application.rb:176:in `key_generator'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/application.rb:205:in `message_verifier'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/activestorage-5.2.4.4/lib/active_storage/engine.rb:81:in `block (2 levels) in <class:Engine>'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/lazy_load_hooks.rb:69:in `block in execute_hook'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/lazy_load_hooks.rb:62:in `with_execution_control'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/lazy_load_hooks.rb:67:in `execute_hook'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/lazy_load_hooks.rb:52:in `block in run_load_hooks'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/lazy_load_hooks.rb:51:in `each'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/lazy_load_hooks.rb:51:in `run_load_hooks'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/application/finisher.rb:75:in `block in <module:Finisher>'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/initializable.rb:32:in `instance_exec'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/initializable.rb:32:in `run'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/initializable.rb:61:in `block in run_initializers'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/initializable.rb:60:in `run_initializers'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/application.rb:361:in `initialize!'
/home/jeff/ondemand/dev/frame-renderer/config/environment.rb:5:in `<top (required)>'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/application.rb:337:in `require'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/application.rb:337:in `require_environment!'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/railties-5.2.4.4/lib/rails/application.rb:520:in `block in run_tasks_blocks'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/sprockets-rails-3.2.2/lib/sprockets/rails/task.rb:61:in `block (2 levels) in define'
Tasks: TOP => environment
(See full trace by running task with --trace)
Traceback (most recent call last):
	6: from bin/setup:41:in `<main>'
	5: from /home/jeff/.rvm/gems/ruby-2.7.1/gems/rake-13.0.3/lib/rake/file_utils_ext.rb:35:in `chdir'
	4: from /home/jeff/.rvm/rubies/ruby-2.7.1/lib/ruby/2.7.0/fileutils.rb:139:in `cd'
	3: from /home/jeff/.rvm/rubies/ruby-2.7.1/lib/ruby/2.7.0/fileutils.rb:139:in `chdir'
	2: from bin/setup:54:in `block in <main>'
	1: from /home/jeff/.rvm/gems/ruby-2.7.1/gems/rake-13.0.3/lib/rake/file_utils.rb:57:in `sh'
/home/jeff/.rvm/gems/ruby-2.7.1/gems/rake-13.0.3/lib/rake/file_utils.rb:67:in `block in create_shell_runner': Command failed with status (1): [bin/rake assets:clobber...] (RuntimeError)
```