### PR TITLE
rake can fail if dependencies are unmet, so just use /dev/urandom

### DIFF
--- a/packaging/frame_renderer.spec
+++ b/packaging/frame_renderer.spec
@@ -46,7 +46,7 @@ scl enable ondemand - << \EOS
 export GEM_HOME=$(pwd)/gems-build
 export GEM_PATH=$(pwd)/gems-build:$GEM_PATH
 export PASSENGER_APP_ENV=production
-export SECRET_KEY_BASE=$(bin/rake secret)
+export SECRET_KEY_BASE=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 128 | head -n 1)
 bin/setup
 EOS
 


### PR DESCRIPTION
rake can fail if dependencies are unmet, so just use /dev/urandom