### PR TITLE
cast params to hash

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,7 +17,7 @@ class Project < ApplicationRecord
 
   def initialize(params = {})
     super
-    write_attribute(:directory, params[:directory] ||= Project.maya_top_level_dir)
+    write_attribute(:directory, params.to_h[:directory] ||= Project.maya_top_level_dir)
   end
 
   def scenes


### PR DESCRIPTION
Apparently in the rails upgrade `params` get's passed in as nil, so this is a bugfix to cast to a hash so that we can access [:directory]. 

For documentation, this is a fatal error where users cannot create new projects. Here's the stack-trace.
```
App 67731 output: [2021-03-25 15:44:20 -0400 ]  INFO "method=GET path=/pun/sys/frame-renderer/projects/new format=html controller=ProjectsController action=new status=500 error='NoMethodError: undefined method `
[]' for nil:NilClass' duration=0.99 view=0.00 db=0.00"
App 67731 output: [2021-03-25 15:44:20 -0400 ] FATAL ""
App 67731 output: [2021-03-25 15:44:20 -0400 ] FATAL "NoMethodError (undefined method `[]' for nil:NilClass):"
App 67731 output: [2021-03-25 15:44:20 -0400 ] FATAL ""
App 67731 output: [2021-03-25 15:44:20 -0400 ] FATAL "app/models/project.rb:20:in `initialize'\napp/controllers/projects_controller.rb:6:in `new'"
```