### PR TITLE
specify rails version in migrations

### DIFF
--- a/db/migrate/20190730164037_create_projects.rb
+++ b/db/migrate/20190730164037_create_projects.rb
@@ -1,4 +1,4 @@
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[4.2]
   def change
     create_table :projects do |t|
       t.string :name

--- a/db/migrate/20190802201653_create_submissions.rb
+++ b/db/migrate/20190802201653_create_submissions.rb
@@ -1,4 +1,4 @@
-class CreateSubmissions < ActiveRecord::Migration
+class CreateSubmissions < ActiveRecord::Migration[4.2]
   def change
     create_table :submissions do |t|
       t.string :name

--- a/db/migrate/20190806151102_create_jobs.rb
+++ b/db/migrate/20190806151102_create_jobs.rb
@@ -1,4 +1,4 @@
-class CreateJobs < ActiveRecord::Migration
+class CreateJobs < ActiveRecord::Migration[4.2]
   def change
     create_table :jobs do |t|
       t.string :status

--- a/db/migrate/20190830155236_change_scheduled_hrs_name.rb
+++ b/db/migrate/20190830155236_change_scheduled_hrs_name.rb
@@ -1,4 +1,4 @@
-class ChangeScheduledHrsName < ActiveRecord::Migration
+class ChangeScheduledHrsName < ActiveRecord::Migration[4.2]
   def change
     change_table :submissions do |t|
       t.rename :scheduled_hrs, :walltime

--- a/db/migrate/20190830194435_change_submission_to_script.rb
+++ b/db/migrate/20190830194435_change_submission_to_script.rb
@@ -1,4 +1,4 @@
-class ChangeSubmissionToScript < ActiveRecord::Migration
+class ChangeSubmissionToScript < ActiveRecord::Migration[4.2]
   def change
     rename_table :submissions, :scripts
 

--- a/db/migrate/20190903150002_add_nodes_to_scripts.rb
+++ b/db/migrate/20190903150002_add_nodes_to_scripts.rb
@@ -1,4 +1,4 @@
-class AddNodesToScripts < ActiveRecord::Migration
+class AddNodesToScripts < ActiveRecord::Migration[4.2]
   def change
     add_column :scripts, :nodes, :integer, default: 1
   end

--- a/db/migrate/20190904153555_add_directory_to_job.rb
+++ b/db/migrate/20190904153555_add_directory_to_job.rb
@@ -1,4 +1,4 @@
-class AddDirectoryToJob < ActiveRecord::Migration
+class AddDirectoryToJob < ActiveRecord::Migration[4.2]
   def change
     add_column :jobs, :directory, :string
   end

--- a/db/migrate/20190905151304_add_escape_hatches.rb
+++ b/db/migrate/20190905151304_add_escape_hatches.rb
@@ -1,4 +1,4 @@
-class AddEscapeHatches < ActiveRecord::Migration
+class AddEscapeHatches < ActiveRecord::Migration[4.2]
   def change
     add_column :jobs, :job_attrs, :text, default: ''
     add_column :scripts, :script_attrs, :text, default: ''

--- a/db/migrate/20190913190913_add_accounting_id_to_scripts.rb
+++ b/db/migrate/20190913190913_add_accounting_id_to_scripts.rb
@@ -1,4 +1,4 @@
-class AddAccountingIdToScripts < ActiveRecord::Migration
+class AddAccountingIdToScripts < ActiveRecord::Migration[4.2]
   def change
     add_column :scripts, :accounting_id, :string
   end

--- a/db/migrate/20190916191322_create_json_store.rb
+++ b/db/migrate/20190916191322_create_json_store.rb
@@ -1,4 +1,4 @@
-class CreateJsonStore < ActiveRecord::Migration
+class CreateJsonStore < ActiveRecord::Migration[4.2]
   def change
     create_table :json_stores do |t|
       t.text :json_attrs

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,56 +10,53 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190916191322) do
+ActiveRecord::Schema.define(version: 2019_09_16_191322) do
 
   create_table "jobs", force: :cascade do |t|
-    t.string   "status"
-    t.string   "job_id"
-    t.string   "cluster"
-    t.integer  "script_id"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.string   "directory"
-    t.text     "job_attrs",  default: ""
+    t.string "status"
+    t.string "job_id"
+    t.string "cluster"
+    t.integer "script_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "directory"
+    t.text "job_attrs", default: ""
+    t.index ["script_id"], name: "index_jobs_on_script_id"
   end
-
-  add_index "jobs", ["script_id"], name: "index_jobs_on_script_id"
 
   create_table "json_stores", force: :cascade do |t|
-    t.text   "json_attrs"
+    t.text "json_attrs"
     t.string "type"
+    t.index ["type"], name: "index_json_stores_on_type"
   end
 
-  add_index "json_stores", ["type"], name: "index_json_stores_on_type"
-
   create_table "projects", force: :cascade do |t|
-    t.string   "name"
-    t.text     "description"
-    t.string   "directory"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.text     "project_attrs", default: ""
+    t.string "name"
+    t.text "description"
+    t.string "directory"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "project_attrs", default: ""
   end
 
   create_table "scripts", force: :cascade do |t|
-    t.string   "name"
-    t.string   "frames"
-    t.string   "camera"
-    t.string   "renderer"
-    t.string   "extra"
-    t.string   "file"
-    t.string   "cluster"
-    t.integer  "walltime"
-    t.boolean  "email"
-    t.boolean  "skip_existing"
-    t.integer  "project_id"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.integer  "nodes",         default: 1
-    t.text     "script_attrs",  default: ""
-    t.string   "accounting_id"
+    t.string "name"
+    t.string "frames"
+    t.string "camera"
+    t.string "renderer"
+    t.string "extra"
+    t.string "file"
+    t.string "cluster"
+    t.integer "walltime"
+    t.boolean "email"
+    t.boolean "skip_existing"
+    t.integer "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "nodes", default: 1
+    t.text "script_attrs", default: ""
+    t.string "accounting_id"
+    t.index ["project_id"], name: "index_scripts_on_project_id"
   end
-
-  add_index "scripts", ["project_id"], name: "index_scripts_on_project_id"
 
 end


### PR DESCRIPTION
specify rails version in migrations because migrations fail with this error

```text
Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateProjects < ActiveRecord::Migration[4.2]
/users/PZS0714/johrstrom/.gem/ruby-2.7.1/gems/activerecord-5.2.6/lib/active_record/migration.rb:528:in `inherited'
/users/PZS0714/johrstrom/ondemand/dev/frame-renderer/db/migrate/20190730164037_create_projects.rb:1:in `<top (required)>'
/users/PZS0714/johrstrom/.gem/ruby-2.7.1/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:291:in `require'
/users/PZS0714/johrstrom/.gem/ruby-2.7.1/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:291:in `block in require'