### PR TITLE
normalize the result image name

### DIFF
--- a/app/models/v_ray_script.rb
+++ b/app/models/v_ray_script.rb
@@ -26,4 +26,8 @@ class VRayScript < Script
   def job_name
     'vray-render'
   end
+
+  def normalized_name
+    name.parameterize(separator: '_')
+  end
 end

--- a/jobs/video_jobs/vray_submit.sh.erb
+++ b/jobs/video_jobs/vray_submit.sh.erb
@@ -49,7 +49,7 @@ UTILS
 mkdir -p "<%= project_dir %>/images"
 
 vray.bin -sceneFile="<%= Shellwords.escape(file) %>" \
-  -imgFile='<%= "#{project_dir}/images/#{Shellwords.escape(name)}.exr" %>' \
+  -imgFile='<%= "#{project_dir}/images/#{normalized_name}.exr" %>' \
   -rtEngine=<%= renderer %> \
   -distributed=0 \
   -skipExistingFrames=<%= skip_existing ? '1' : '0' %> \


### PR DESCRIPTION
normalize the result image name to avoid things like spaces and $s and other strange characters.