### PR TITLE
use 2.0 (ruby 2.7) ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,11 +4,12 @@ variables:
   OOD_PACKAGING_DEBUG: 'true'
   OOD_PACKAGING_GPG_PRIVATE_KEY: /systems/osc_certs/gpg/ondemand/ondemand.sec
   OOD_PACKAGING_GPG_PASSPHRASE: /systems/osc_certs/gpg/ondemand/.gpgpass
+  OOD_PACKAGING_RELEASE: '2.0'
 
 before_script:
   - docker info
   - '[ -d tmp ] || mkdir tmp'
-  - git clone --branch main https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
+  - git clone --single-branch --branch $OOD_PACKAGING_RELEASE https://github.com/OSC/ondemand-packaging.git tmp/ondemand-packaging
 stages:
   - build
   - deploy


### PR DESCRIPTION
@treydock I need to build these RPMs against ruby 2.7.  I believe this would do it. Please advise.