### PR TITLE
keep using ruby 2.7

### DIFF
--- a/bin/ruby
+++ b/bin/ruby
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source scl_source enable rh-ruby27
+exec /bin/env ruby "$@"


### PR DESCRIPTION
keep using ruby 2.7 because we're deploying ondemand 2.1 which uses ruby 3.0.