### PR TITLE
use ALLOWED_HOSTS env var and default to empty hosts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,5 +111,5 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  config.hosts = ENV['OOD_PUN_RAILS_CONFIG_HOSTS'].nil? ? nil : ENV['OOD_PUN_RAILS_CONFIG_HOSTS'].split(',')
+  config.hosts = ENV['ALLOWED_HOSTS'].nil? ? [] : ENV['ALLOWED_HOSTS'].split(',')
 end


### PR DESCRIPTION
use ALLOWED_HOSTS env var and default to empty hosts because I'm sure that `nil` is working by coincidence and this app is safe to update to default to something more stringent than `nil`.