### PR TITLE
enable maya 2023

### DIFF
--- a/app/models/maya_script.rb
+++ b/app/models/maya_script.rb
@@ -26,7 +26,7 @@ class MayaScript < Script
   end
 
   def available_versions
-    ['2020', '2022']
+    ['2020', '2022', '2023']
   end
 
   def job_name

--- a/jobs/video_jobs/maya_submit.sh.erb
+++ b/jobs/video_jobs/maya_submit.sh.erb
@@ -50,7 +50,6 @@ echo "starting at $(date)"
 module purge
 #load the singularity and ACCAD modules and record the loaded module list
 module use /usr/local/share/lmodfiles/project/osc
-module load singularity/current
 module load ruby
 
 <%
@@ -89,7 +88,8 @@ END_FRAMES=(shift <%= task_end_frames.join(' ')%>)
 export TASK_START_FRAME=${START_FRAMES[$SLURM_ARRAY_TASK_ID]}
 export TASK_END_FRAME=${END_FRAMES[$SLURM_ARRAY_TASK_ID]}
 
-CMD=(singularity exec -B $BIND_DIRS $MAYA_IMG Render)
+ulimit -c 0
+CMD=(apptainer exec -B $BIND_DIRS $MAYA_IMG Render)
 CMD+=(-r $RENDERER $SKIP_EXISTING ${EXTRA_ARGS} -proj $PRJ_DIR -s $TASK_START_FRAME -e $TASK_END_FRAME)
 
 echo "executing: ${CMD[@]} <%= Shellwords.escape(file) %>"


### PR DESCRIPTION
enable maya 2023 - and disable core dumps because this version throws core dumps. 