### PR TITLE
use 4.0 packaging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ variables:
   OOD_PACKAGING_DEBUG: 'true'
   OOD_PACKAGING_GPG_PRIVATE_KEY: /systems/osc_certs/gpg/ondemand/ondemand.sec
   OOD_PACKAGING_GPG_PASSPHRASE: /systems/osc_certs/gpg/ondemand/.gpgpass
-  OOD_PACKAGING_RELEASE: '3.1'
+  OOD_PACKAGING_RELEASE: '4.0'
 
 before_script:
   - docker info


### PR DESCRIPTION
use 4.0 packaging to be deployed on 4.0 systems.